### PR TITLE
feat: add Radarr multiple tags support, fix collection ordering, and …

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -75,7 +75,14 @@ radarr:
   url: "http://localhost:7878"                      # Your Radarr server URL
   api_key: "RADARR_API_KEY"                         # Replace with your Radarr API key
   root_folder: "/folder/to/you/Movies"              # Root folder for movie downloads
-  tag_name: "RADARR_TAG_NAME"                       # Tag to apply to added movies
+  
+  # Tag(s) to apply to added movies
+  # Option 1: Single tag (string)
+  tag_name: "recommended"
+  # Option 2: Multiple tags (list) - uncomment and use this format instead:
+  # tag_name: ["movies", "curated"]
+  # Both formats are supported - choose the one that fits your needs
+  
   quality_profile_id: 1                             # Quality profile ID (default: 1)
 
 # ============================================================================

--- a/src/tautulli_curated/helpers/config_loader.py
+++ b/src/tautulli_curated/helpers/config_loader.py
@@ -41,7 +41,7 @@ class RadarrConfig:
     url: str
     api_key: str
     root_folder: str
-    tag_name: str
+    tag_name: str | list[str]  # Can be a single tag (string) or multiple tags (list)
     quality_profile_id: int = 1
 
 

--- a/src/tautulli_curated/helpers/radarr_utils.py
+++ b/src/tautulli_curated/helpers/radarr_utils.py
@@ -151,9 +151,14 @@ def radarr_add_and_search(cfg, title: str) -> Tuple[bool, str]:
     """
     tag_ids = []
     if cfg.radarr.tag_name:
-        tag_id = get_or_create_tag(cfg, cfg.radarr.tag_name)
-        if tag_id:
-            tag_ids = [tag_id]
+        # Handle both single tag (string) and multiple tags (list) for backward compatibility
+        tag_names = cfg.radarr.tag_name if isinstance(cfg.radarr.tag_name, list) else [cfg.radarr.tag_name]
+        
+        for tag_name in tag_names:
+            if tag_name:  # Skip empty strings
+                tag_id = get_or_create_tag(cfg, tag_name)
+                if tag_id:
+                    tag_ids.append(tag_id)
 
     looked_up = radarr_lookup_movie(cfg, title)
     if not looked_up or not looked_up.get("tmdbId"):

--- a/src/tautulli_curated/helpers/recently_watched_collection.py
+++ b/src/tautulli_curated/helpers/recently_watched_collection.py
@@ -86,34 +86,47 @@ def run_recently_watched_playlist(movie_name, config):
                     })
                 else:
                     logger.debug(f"  Missing in Plex: {title}")
+                    # Still add to collection_movies (without rating_key) so it can be added later if downloaded
+                    collection_movies.append({
+                        "title": title.strip(),
+                        "rating_key": None,
+                        "year": None,
+                    })
                     key = title.strip().lower()
                     if key and key not in missing_seen:
                         missing_seen.add(key)
                         missing_in_plex.append(title.strip())
             except Exception as e:
                 logger.warning(f"  Error checking '{title}' in Plex: {e}")
+                # Still add to collection_movies (without rating_key) so it can be added later if downloaded
+                collection_movies.append({
+                    "title": title.strip(),
+                    "rating_key": None,
+                    "year": None,
+                })
                 # Continue processing other movies
                 key = title.strip().lower()
                 if key and key not in missing_seen:
                     missing_seen.add(key)
                     missing_in_plex.append(title.strip())
 
-        logger.info(f"  ✓ Found {len(collection_movies)} movies in Plex")
-        logger.info(f"  ✓ {len(missing_in_plex)} movies missing in Plex")
+        logger.info(f"  ✓ Found {len(collection_movies) - len(missing_in_plex)} movies in Plex")
+        logger.info(f"  ✓ {len(missing_in_plex)} movies missing in Plex (will be added to JSON for future refresh)")
 
-        # Save to JSON (will be applied to Plex by midnight script)
+        # Save to JSON (ALL recommendations - found and missing)
+        # The refresher will skip missing movies and add them when they become available
         saved_to_json = False
         if collection_movies:
             try:
                 save_collection_to_json(collection_movies, JSON_FILE, config)
-                logger.info(f"Step 3: Saved {len(collection_movies)} movies to {JSON_FILE}")
-                logger.info(f"  ✓ Collection state saved (will be applied by midnight refresher)")
+                logger.info(f"Step 3: Saved {len(collection_movies)} movies to {JSON_FILE} (including {len(missing_in_plex)} not yet in Plex)")
+                logger.info(f"  ✓ Collection state saved (will be applied by refresher - missing movies will be skipped until downloaded)")
                 saved_to_json = True
             except Exception as e:
                 logger.error(f"  ✗ Failed to save collection to JSON: {e}")
                 raise
         else:
-            logger.warning(f"Step 3: No movies found in Plex to save to collection")
+            logger.warning(f"Step 3: No recommendations to save to collection")
 
         # Radarr processing for missing titles
         sent_to_radarr = 0

--- a/src/tautulli_curated/main.py
+++ b/src/tautulli_curated/main.py
@@ -24,6 +24,15 @@ def main():
     logger.info(f"Media type: {media_type}")
     logger.info("")
 
+    # Early exit if media type is not "movie"
+    if media_type not in ("movie",):
+        logger.info(f"This script only processes movies. Detected media type: '{media_type}' (episode/show)")
+        logger.info("Skipping entire script - no actions will be performed.")
+        logger.info("=" * 60)
+        logger.info("TAUTULLI CURATED COLLECTION SCRIPTS END (skipped - not a movie)")
+        logger.info("=" * 60)
+        return 0
+
     try:
         # Load configuration
         logger.info("Loading configuration...")


### PR DESCRIPTION
…skip non-movie media

- Add support for multiple Radarr tags (backward compatible with single tag)
  - Updated RadarrConfig to accept str | list[str] for tag_name
  - Modified radarr_add_and_search to handle multiple tags
  - Updated config.yaml documentation

- Fix custom order application in recently_watched_collections_refresher
  - Added _apply_custom_order call after adding items to collection
  - Ensures randomized order is actually applied in Plex

- Add early exit for non-movie media types in main script
  - Skip entire script execution if media_type is episode/show
  - Logs clear message about skipping non-movie content